### PR TITLE
Add support for text_data attribute in lego_sensor_class

### DIFF
--- a/include/lego_sensor_class.h
+++ b/include/lego_sensor_class.h
@@ -125,7 +125,7 @@ struct lego_sensor_device {
 	ssize_t (*direct_write)(void *context, char *data, loff_t off, size_t count);
 	int (* get_poll_ms)(void *context);
 	int (* set_poll_ms)(void *context, unsigned value);
-	ssize_t (*text_data_read)(char *data, size_t count);
+	ssize_t (*text_value_read)(char *data, size_t count);
 	void *context;
 	char fw_version[LEGO_SENSOR_FW_VERSION_SIZE + 1];
 	/* private */

--- a/include/lego_sensor_class.h
+++ b/include/lego_sensor_class.h
@@ -2,6 +2,7 @@
  * LEGO sensor device class
  *
  * Copyright (C) 2014-2015 David Lechner <david@lechnology.com>
+ * Copyright (C) 2015-     Ralph Hempel <rhempel@hempeldesigngroup.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
@@ -124,6 +125,7 @@ struct lego_sensor_device {
 	ssize_t (*direct_write)(void *context, char *data, loff_t off, size_t count);
 	int (* get_poll_ms)(void *context);
 	int (* set_poll_ms)(void *context, unsigned value);
+	ssize_t (*text_data_read)(char *data, size_t count);
 	void *context;
 	char fw_version[LEGO_SENSOR_FW_VERSION_SIZE + 1];
 	/* private */

--- a/sensors/lego_sensor_class.c
+++ b/sensors/lego_sensor_class.c
@@ -2,6 +2,7 @@
  * LEGO sensor device class
  *
  * Copyright (C) 2013-2015 David Lechner <david@lechnology.com>
+ * Copyright (C) 2015      Ralph Hempel <rhempel@hempeldesigngroup.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
@@ -121,6 +122,11 @@
  *   see how many values there are. Values with N >= num_values will return an
  *   error. The values are fixed point numbers, so check `decimals` to see if
  *   you need to divide to get the actual value.
+ * .
+ * `text_data` (read-only)
+ * : Returns a string representing sensor-specific text data. The string may
+ *   contain embedded line feed characters, is limited to PAGE_SIZE bytes
+ *   in length, and has a trailing linefeed
  * .
  * ### Events
  * .
@@ -511,6 +517,17 @@ static ssize_t fw_version_show(struct device *dev, struct device_attribute *attr
 	return snprintf(buf, LEGO_SENSOR_FW_VERSION_SIZE + 2, "%s\n", sensor->fw_version);
 }
 
+static ssize_t text_data_show(struct device *dev, struct device_attribute *attr,
+			      char *buf)
+{
+	struct lego_sensor_device *sensor = to_lego_sensor_device(dev);
+
+	if (!sensor->text_data_read)
+		return -EOPNOTSUPP;
+
+        return sensor->text_data_read(buf, PAGE_SIZE);
+}
+
 static ssize_t bin_data_read(struct file *file, struct kobject *kobj,
 			     struct bin_attribute *attr,
 			     char *buf, loff_t off, size_t count)
@@ -567,6 +584,7 @@ static DEVICE_ATTR_RO(units);
 static DEVICE_ATTR_RO(decimals);
 static DEVICE_ATTR_RO(num_values);
 static DEVICE_ATTR_RO(bin_data_format);
+static DEVICE_ATTR_RO(text_data);
 /*
  * Technically, it is possible to have 32 8-bit values from UART sensors
  * and >200 8-bit values from I2C sensors, but known UART sensors so far
@@ -596,6 +614,7 @@ static struct attribute *lego_sensor_class_attrs[] = {
 	&dev_attr_decimals.attr,
 	&dev_attr_num_values.attr,
 	&dev_attr_bin_data_format.attr,
+	&dev_attr_text_data.attr,
 	&dev_attr_value0.attr,
 	&dev_attr_value1.attr,
 	&dev_attr_value2.attr,

--- a/sensors/lego_sensor_class.c
+++ b/sensors/lego_sensor_class.c
@@ -123,8 +123,8 @@
  *   error. The values are fixed point numbers, so check `decimals` to see if
  *   you need to divide to get the actual value.
  * .
- * `text_data` (read-only)
- * : Returns a string representing sensor-specific text data. The string may
+ * `text_value` (read-only)
+ * : Returns a string representing sensor-specific text value. The string may
  *   contain embedded line feed characters, is limited to PAGE_SIZE bytes
  *   in length, and has a trailing linefeed
  * .
@@ -517,15 +517,15 @@ static ssize_t fw_version_show(struct device *dev, struct device_attribute *attr
 	return snprintf(buf, LEGO_SENSOR_FW_VERSION_SIZE + 2, "%s\n", sensor->fw_version);
 }
 
-static ssize_t text_data_show(struct device *dev, struct device_attribute *attr,
+static ssize_t text_value_show(struct device *dev, struct device_attribute *attr,
 			      char *buf)
 {
 	struct lego_sensor_device *sensor = to_lego_sensor_device(dev);
 
-	if (!sensor->text_data_read)
+	if (!sensor->text_value_read)
 		return -EOPNOTSUPP;
 
-        return sensor->text_data_read(buf, PAGE_SIZE);
+        return sensor->text_value_read(buf, PAGE_SIZE);
 }
 
 static ssize_t bin_data_read(struct file *file, struct kobject *kobj,
@@ -584,7 +584,7 @@ static DEVICE_ATTR_RO(units);
 static DEVICE_ATTR_RO(decimals);
 static DEVICE_ATTR_RO(num_values);
 static DEVICE_ATTR_RO(bin_data_format);
-static DEVICE_ATTR_RO(text_data);
+static DEVICE_ATTR_RO(text_value);
 /*
  * Technically, it is possible to have 32 8-bit values from UART sensors
  * and >200 8-bit values from I2C sensors, but known UART sensors so far
@@ -614,7 +614,7 @@ static struct attribute *lego_sensor_class_attrs[] = {
 	&dev_attr_decimals.attr,
 	&dev_attr_num_values.attr,
 	&dev_attr_bin_data_format.attr,
-	&dev_attr_text_data.attr,
+	&dev_attr_text_value.attr,
 	&dev_attr_value0.attr,
 	&dev_attr_value1.attr,
 	&dev_attr_value2.attr,


### PR DESCRIPTION
This is the first in a series of pull requests with separate commits - first step is add support for `text_data` attribute
